### PR TITLE
Update link to deploying on k8s

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -162,7 +162,7 @@
                 <div class="document">
                     <div class="document-wrap">
                         <div class="document-title">
-                            <h2><a href="https://github.com/vmware/harbor/blob/master/docs/kubernetes_deployment.md" target="_blank">Deploy Harbor on Kubernetes</a></h2>
+                            <h2><a href="https://github.com/goharbor/harbor-helm" target="_blank">Deploy Harbor on Kubernetes</a></h2>
                         </div>
                         <div class="document-description">
                             Guide to deploy Harbor on Kubernetes. (maintained by community)


### PR DESCRIPTION
The existing link refers to a deprecate document. This PR updates the link to refer to the helm chart.